### PR TITLE
Ide : add Clear Output to menu

### DIFF
--- a/ObxIde2.cpp
+++ b/ObxIde2.cpp
@@ -807,7 +807,9 @@ void Ide::createMenuBar()
     pop->addCommand( "Export IL...", this, SLOT(onExportIl()) );
     pop->addCommand( "Export C...", this, SLOT(onExportC()) );
     pop->addCommand( "Run", this, SLOT(onRun()), tr("CTRL+R"), false );
-
+    pop->addSeparator();
+    pop->addCommand( "Clear Output", this, SLOT(onClearTerm()), tr("CTRL+SHIFT+C"), false );
+    
     pop = new Gui::AutoMenu( tr("Debug"), this );
     pop->addCommand( "Enable Debugging", this, SLOT(onEnableDebug()),tr(OBN_ENDBG_SC), false );
     pop->addCommand( "Bytecode mode", this, SLOT(onByteMode()) );
@@ -1647,6 +1649,12 @@ void Ide::onBreak()
     // we cannot support break yet because Mono might stop at a place where a step command leads to a VM crash.
     //d_suspended = true;
     //d_dbg->suspend();
+}
+
+void Ide::onClearTerm()
+{
+    ENABLED_IF(true);
+    d_term->clear();
 }
 
 bool Ide::checkSaved(const QString& title)

--- a/ObxIde2.h
+++ b/ObxIde2.h
@@ -147,6 +147,7 @@ namespace Obx
         void onRemoveDir();
         void onEnableDebug();
         void onBreak();
+        void onClearTerm();
         void handleGoBack();
         void handleGoForward();
         void onUpdateLocation(int line, int col );


### PR DESCRIPTION
Currently the functionality to clear the output is hidden from the user. 
This changes add this to the menu for discoverability.